### PR TITLE
Implementing total order

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,5 +56,5 @@ Replication log is a distributed systems course homework [assignment](https://do
     docker-compose up --build test
 
     # locally (from the folder ./integration)
-     MASTER_HOST=localhost MASTER_PORT=8080 SECONDARY_1_HOST=localhost SECONDARY_1_PORT=8081 SECONDARY_2_HOST=localhost SECONDARY_2_PORT=8082 go test -count=1
+     MASTER_HOST=localhost MASTER_PORT=8080 SECONDARY_1_HOST=localhost SECONDARY_1_PORT=8081 SECONDARY_2_HOST=localhost SECONDARY_2_PORT=8082 go test -count=1 -p=1
 ```

--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -6,4 +6,4 @@ COPY . .
 
 RUN go mod download
 
-CMD [ "go", "test", "/app", "-count=1" ]
+CMD [ "go", "test", "/app", "-count=1", "-p=1" ]

--- a/integration/client.go
+++ b/integration/client.go
@@ -68,3 +68,15 @@ func (t *Client) PostMessage(m Message) error {
 
 	return nil
 }
+
+func (t *Client) Flush() error {
+	resp, err := t.R().Post(t.address + "/flush")
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return fmt.Errorf("expecting status created, got: %d", resp.StatusCode())
+	}
+
+	return nil
+}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -66,7 +66,7 @@ var _ = It("A delay is respected", func() {
 	}
 })
 
-var _ = It("Many messages get replicated", func() {
+var _ = It("Total order is respected", func() {
 	m, ss := env()
 
 	var msgs []integration.Message
@@ -89,10 +89,16 @@ var _ = It("Many messages get replicated", func() {
 	}
 	wg.Wait()
 
-	for _, c := range append(ss, m) {
+	// Master generally doesn't have the same order as `msgs` because there are no guarantees when an exact message will get to master.
+	// So we're asserting here that all the messages eventually get to master (even if in a scrumbled order).
+	masterMessages, err := m.GetMessages()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(masterMessages).To(ContainElements(expected))
+
+	for _, c := range ss {
 		result, err := c.GetMessages()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(result).To(ContainElements(expected))
+		Expect(result).To(Equal(masterMessages), "All the replicas should have messages in the order that's defined by master")
 	}
 })
 
@@ -370,6 +376,8 @@ var _ = It("If w=2 and secondary-2 returned the result, not waiting for secondar
 	takesAtMost(func() {
 		Expect(m.PostMessage(msg)).To(Succeed())
 	}, 2*time.Second)
+
+	time.Sleep(4 * time.Second) // Sleeping not to corrupt the other tests.
 })
 
 var _ = It("If w=2 and secondary-1 returned the result, not waiting for secondary-2", func() {
@@ -382,6 +390,8 @@ var _ = It("If w=2 and secondary-1 returned the result, not waiting for secondar
 	takesAtMost(func() {
 		Expect(m.PostMessage(msg)).To(Succeed())
 	}, 2*time.Second)
+
+	time.Sleep(4 * time.Second) // Sleeping not to corrupt the other tests.
 })
 
 var _ = It("If w=1, not waiting at all", func() {
@@ -395,6 +405,99 @@ var _ = It("If w=1, not waiting at all", func() {
 	takesAtMost(func() {
 		Expect(m.PostMessage(msg)).To(Succeed())
 	}, 1*time.Second)
+
+	time.Sleep(4 * time.Second) // Sleeping not to corrupt the other tests.
+})
+
+var _ = It("Messages get delivered only after previous messages are delivered", func() {
+	m, ss := env()
+
+	// Posting the first message.
+	a := makeMessage()
+	Expect(m.PostMessage(a)).To(Succeed())
+
+	// Posting the second message with a huge delay for secondaries.
+	b := makeMessage()
+	b.WriteConcern = 1     // Master doesn't wait for secondaries.
+	b.Secondary1.Delay = 3 // In seconds.
+	b.Secondary2.Delay = 3 // In seconds.
+	takesAtMost(func() {
+		Expect(m.PostMessage(b)).To(Succeed())
+	}, 1*time.Second)
+
+	msgs, err := m.GetMessages()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(msgs).To(Equal([]string{a.Message, b.Message}), "Master should show all the messages, even those that are not yet delivered to secondaries")
+
+	for _, s := range ss {
+		msgs, err := s.GetMessages()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(msgs).To(Equal([]string{a.Message}), "Secondaries shouldn't show the second message yet because of delays")
+	}
+
+	// Posting the third message without delays that should get to secondaries before the second message.
+	c := makeMessage()
+	Expect(m.PostMessage(c)).To(Succeed())
+
+	msgs, err = m.GetMessages()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(msgs).To(Equal([]string{a.Message, b.Message, c.Message}), "Master should show all the messages once again")
+
+	for _, s := range ss {
+		msgs, err := s.GetMessages()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(msgs).To(Equal([]string{a.Message}), "Secondaries shouldn't show the third message before the second one gets delivered")
+	}
+
+	Eventually(func(g Gomega) {
+		for _, s := range ss {
+			msgs, err := s.GetMessages()
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(msgs).To(Equal([]string{a.Message, b.Message, c.Message}), "Secondaries should eventually deliver all the messages in the right order")
+		}
+	}, 4*time.Second /* timeout */, 500*time.Millisecond /* polling interval */).Should(Succeed())
+})
+
+var _ = It("Secondaries deduplicate by ID (this test involves internals)", func() {
+	_, ss := env()
+
+	msg := makeMessage()
+	msg.ID = 0
+
+	for i := 0; i < 10; i++ {
+		for _, s := range ss {
+			Expect(s.PostMessage(msg)).To(Succeed())
+		}
+	}
+
+	for _, s := range ss {
+		msgs, err := s.GetMessages()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(msgs).To(Equal([]string{msg.Message}))
+	}
+})
+
+var _ = It("Secondaries deliver in the ID order starting from zero (this test involves internals)", func() {
+	_, ss := env()
+	s := ss[0]
+
+	a := makeMessage()
+	a.ID = 1
+
+	Expect(s.PostMessage(a)).To(Succeed())
+
+	msgs, err := s.GetMessages()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(msgs).To(BeEmpty(), "Message with ID 1 shouldn't be delivered before ID zero is")
+
+	b := makeMessage()
+	b.ID = 0
+
+	Expect(s.PostMessage(b)).To(Succeed())
+
+	msgs, err = s.GetMessages()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(msgs).To(Equal([]string{b.Message, a.Message}), "Secondaries should eventually deliver both messages in the right order")
 })
 
 func env() (*integration.Client, []*integration.Client) {
@@ -416,7 +519,12 @@ func env() (*integration.Client, []*integration.Client) {
 	s2, err := integration.NewClient(c)
 	Expect(err).NotTo(HaveOccurred())
 
-	return m, []*integration.Client{s1, s2}
+	ss := []*integration.Client{s1, s2}
+	for _, c := range append(ss, m) {
+		c.Flush()
+	}
+
+	return m, ss
 }
 
 func takesAtLeast(f func(), t time.Duration) {

--- a/integration/message.go
+++ b/integration/message.go
@@ -5,6 +5,8 @@ type Message struct {
 	WriteConcern int             `json:"w"`
 	Secondary1   SecondaryConfig `json:"secondary-1"`
 	Secondary2   SecondaryConfig `json:"secondary-2"`
+	// ID is only used for testing behavior of secondaries by direct POSTs to them (which is not allowed to users).
+	ID int `json:"id"`
 }
 
 type SecondaryConfig struct {

--- a/secondary/app.py
+++ b/secondary/app.py
@@ -6,13 +6,17 @@ import sys
 
 app = Flask(__name__)
 
-data = []
-message_ids = set()
 lock = Lock()
+id_to_message_in_staging = {}
+messages = []
+message_ids = set()
+next_id = 0
 
 
 @app.route("/messages", methods=["POST"])
 def post():
+    global next_id
+
     print(request.json, file=sys.stderr)
 
     noreply = request.json.get("noreply")
@@ -28,17 +32,39 @@ def post():
     msg = request.json.get("message")
     with lock:
         if id_ not in message_ids:
-            data.append(msg)
+            # Adding an id for deduplication.
             message_ids.add(id_)
+
+            # Adding the message to staging.
+            id_to_message_in_staging[id_] = msg
+
+            # Checking if there are messages that are ready to be delivered.
+            while next_id in id_to_message_in_staging:
+                messages.append(id_to_message_in_staging[next_id])
+                del id_to_message_in_staging[next_id]
+                next_id = next_id + 1
 
     return jsonify(msg)
 
 
 @app.route('/messages', methods=['GET'])
 def get():
-    return jsonify(data)
+    return jsonify(messages)
 
 
 @app.route("/ping", methods=["GET"])
 def ping():
     return "pong"
+
+
+@app.route('/flush', methods=['POST'])
+def flush():
+    global next_id
+
+    with lock:
+        id_to_message_in_staging.clear()
+        messages.clear()
+        message_ids.clear()
+        next_id = 0
+
+    return 'ok'


### PR DESCRIPTION
Implementing total order.

This involves sorting messages by ID. Before a message is ready to be delivered, it's saved to a staging dictionary. It's ready to be delivered when an expected ID equals the ID of the message. The base expected ID is zero. Once a message with such an ID is delivered, the ID is incremented.

Total ordering involves changes to tests. For that reason, I had to implement the /flush endpoint to make tests independent.

This is an iteration of the pull request https://github.com/nestoroprysk/repl-log-group/pull/10.

The implementation differs for the following reasons:
- the base pull request is not merged and has conflicting changes
- if there is a single message that's not yet ready to be delivered, it's returned right away (e.g., if secondary received ID 1 before ID 0)
- the complexity of the approach is high (it involves sorting)

I'm okay with abandoning this pull request in favor of the base one if it's in the merging state and all the tests (including tests of the current diff) are green.